### PR TITLE
docs: add molecule.sh ChatGPT molecule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ All of these awesome projects use the `chatgpt` package. 🤯
 - [Go Telegram Bot](https://github.com/m1guelpf/chatgpt-telegram)
 - [Github ProBot](https://github.com/oceanlvr/ChatGPTBot)
 - [Lovelines.xyz](https://lovelines.xyz)
+- [EXM smart contracts `molecule`](https://github.com/decentldotland/molecule)
 
 If you create a cool integration, feel free to open a PR and add it to the list.
 


### PR DESCRIPTION
`chatgpt-api` has been wrapped by a molecule.sh 's `molecule` to make it possible for [EXM](https://exm.dev) smart contracts to interact with ChatGPT

- example: https://github.com/decentldotland/molecule/blob/main/examples/chat-gpt/wtf.md