### PR TITLE
Add link to wong2/chat-gpt-google-extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,7 @@ If you create a cool integration, feel free to open a PR and add it to the list.
 
 - Huge thanks to [@RomanHotsiy](https://github.com/RomanHotsiy), [@ElijahPepe](https://github.com/ElijahPepe), and all the other contributors 💪
 - The original browser version was inspired by this [Go module](https://github.com/danielgross/whatsapp-gpt) by [Daniel Gross](https://github.com/danielgross)
-- Thew new version takes code for ChatGPT API request from [chat-gpt-google-extension](https://github.com/wong2/chat-gpt-google-extension) by [@wong2](https://github.com/wong2)
+- The new version takes code for ChatGPT API request from [chat-gpt-google-extension](https://github.com/wong2/chat-gpt-google-extension) by [@wong2](https://github.com/wong2)
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -112,8 +112,9 @@ If you create a cool integration, feel free to open a PR and add it to the list.
 
 ## Credit
 
-- Huge thanks to [@RomanHotsiy](https://github.com/RomanHotsiy), [@ElijahPepe](https://github.com/ElijahPepe), [@wong2](https://github.com/wong2), and all the other contributors 💪
+- Huge thanks to [@RomanHotsiy](https://github.com/RomanHotsiy), [@ElijahPepe](https://github.com/ElijahPepe), and all the other contributors 💪
 - The original browser version was inspired by this [Go module](https://github.com/danielgross/whatsapp-gpt) by [Daniel Gross](https://github.com/danielgross)
+- Thew new version takes code for ChatGPT API request from [chat-gpt-google-extension](https://github.com/wong2/chat-gpt-google-extension) by [@wong2](https://github.com/wong2)
 
 ## License
 


### PR DESCRIPTION
Hi, I noticed the core logic for requesting ChatGPT API is take from my project, so I think it would be nice to add that to README. 😄 