### PR TITLE
Fix "Error: Default condition should be last one" when package is used as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "exports": {
     ".": {
       "import": "./build/index.js",
-      "default": "./build/index.js",
-      "types": "./build/index.d.ts"
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
See https://github.com/mpociot/chatgpt-vscode/issues/1 for details. 

Putting default export as the last in package.json solves this problem.

Lots of people are having trouble getting chatgpt-vscode up and running because of this.