### PR TITLE
Add CarikBot to Projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,7 @@ All of these awesome projects are built using the `chatgpt` package. 🤯
 - [Lovelines.xyz](https://lovelines.xyz)
 - [EXM smart contracts](https://github.com/decentldotland/molecule)
 - [Flutter ChatGPT API](https://github.com/coskuncay/flutter_chatgpt_api)
+- [Carik Bot](https://github.com/luridarmawan/Carik)
 
 If you create a cool integration, feel free to open a PR and add it to the list.
 


### PR DESCRIPTION
added chatgpt on all platforms supported by Carik Bot (telegram, whatsapp, line, facebook messenger, discord, etc).
