### PR TITLE
add Try Again functionality to ChatGPTConversation

### DIFF
--- a/src/chatgpt-conversation.ts
+++ b/src/chatgpt-conversation.ts
@@ -10,6 +10,8 @@ export class ChatGPTConversation {
   api: ChatGPTAPI
   conversationId: string = undefined
   parentMessageId: string = undefined
+  previousParentMessageId: string = undefined
+  previousMessage: string = undefined
 
   /**
    * Creates a new conversation wrapper around the ChatGPT API.
@@ -51,10 +53,59 @@ export class ChatGPTConversation {
   ): Promise<string> {
     const { onConversationResponse, ...rest } = opts
 
+    this.previousMessage = message
+    this.previousParentMessageId = this.parentMessageId
+
     return this.api.sendMessage(message, {
       ...rest,
       conversationId: this.conversationId,
       parentMessageId: this.parentMessageId,
+      onConversationResponse: (response) => {
+        if (response.conversation_id) {
+          this.conversationId = response.conversation_id
+        }
+
+        if (response.message?.id) {
+          this.parentMessageId = response.message.id
+        }
+
+        if (onConversationResponse) {
+          return onConversationResponse(response)
+        }
+      }
+    })
+  }
+
+  /*
+   * Sends the previous message to ChatGPT in previous context, waits for
+   * the response to resolve, and returns the response.
+   *
+   * If there is no previous message, an error will be thrown.
+   *
+   * This allows you to send the same message to ChatGPT multiple times with the same context
+   * and receive different responses, without having to manually repeat them (like Try Again button on the website).
+   *
+   * @param opts.onProgress - Optional callback which will be invoked every time the partial response is updated
+   * @param opts.onConversationResponse - Optional callback which will be invoked every time the partial response is updated with the full conversation response
+   * @param opts.abortSignal - Optional callback used to abort the underlying `fetch` call using an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+   *
+   * @returns The response from ChatGPT
+   */
+  async tryAgain(
+    opts: types.SendConversationMessageOptions = {}
+  ): Promise<string> {
+    const { onConversationResponse, ...rest } = opts
+
+    if (!this.previousMessage || !this.previousParentMessageId) {
+      throw new Error(
+        'ChatGPT cannot try again: no previously sent message in conversation'
+      )
+    }
+
+    return this.api.sendMessage(this.previousMessage, {
+      ...rest,
+      conversationId: this.conversationId,
+      parentMessageId: this.previousParentMessageId,
       onConversationResponse: (response) => {
         if (response.conversation_id) {
           this.conversationId = response.conversation_id


### PR DESCRIPTION
Added `tryAgain`method to `Conversation` class, which acts in the same way as the _"🔄Try Again"_ button on the web, i.e. the previous message is sent to chatGPT again, but with previousMessageId being the same as it was in that request, not updated to the response, so that the model doesn't see its previous response to the same message. 