### PR TITLE
feat: set accessToken while initialize ChatGPTAPI

### DIFF
--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -52,6 +52,8 @@ export class ChatGPTAPI {
 
     /** @defaultValue 60000 (60 seconds) */
     accessTokenTTL?: number
+
+    accessToken?: string
   }) {
     const {
       sessionToken,
@@ -59,7 +61,8 @@ export class ChatGPTAPI {
       apiBaseUrl = 'https://chat.openai.com/api',
       backendApiBaseUrl = 'https://chat.openai.com/backend-api',
       userAgent = USER_AGENT,
-      accessTokenTTL = 60000 // 60 seconds
+      accessTokenTTL = 60000, // 60 seconds
+      accessToken
     } = opts
 
     this._sessionToken = sessionToken
@@ -76,6 +79,7 @@ export class ChatGPTAPI {
     }
 
     this._accessTokenCache = new ExpiryMap<string, string>(accessTokenTTL)
+    this._accessTokenCache.set(KEY_ACCESS_TOKEN, accessToken ?? '')
 
     if (!this._sessionToken) {
       throw new types.ChatGPTError('ChatGPT invalid session token')


### PR DESCRIPTION
In order to avoid encountering request frequency limits, or some other account errors, we need to implement some load balancing strategy, just like manage accounts stored in Redis or MongoDB. 
But if we manage tokens completely through this package, there will be at least one http request for authentication before each request.  It is difficult to build a distributed stateless restAPI service, so I put the accessToken parameter at the end and the default value is set to an empty string for compatibility.

PS: Especially in some areas where network connections are alway not that stable or the network speed is slow, it will cause higher latency and waste more time for waiting the answer from chatGPT.