### PR TITLE
fix env vars in code sample in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,8 +59,8 @@ import { ChatGPTAPI, getOpenAIAuth } from 'chatgpt'
 async function example() {
   // use puppeteer to bypass cloudflare (headful because of captchas)
   const openAIAuth = await getOpenAIAuth({
-    email: process.env.EMAIL,
-    password: process.env.EMAIL
+    email: process.env.OPENAI_EMAIL,
+    password: process.env.OPENAI_PASSWORD
   })
 
   const api = new ChatGPTAPI({ ...openAIAuth })
@@ -121,8 +121,8 @@ async function example() {
   const { ChatGPTAPI, getOpenAIAuth } = await import('chatgpt')
 
   const openAIAuth = await getOpenAIAuth({
-    email: process.env.EMAIL,
-    password: process.env.EMAIL
+    email: process.env.OPENAI_EMAIL,
+    password: process.env.OPENAI_PASSWORD
   })
 
   const api = new ChatGPTAPI({ ...openAIAuth })


### PR DESCRIPTION
This looks like a fun project!

I noticed the code example uses `process.env.EMAIL` for both the email and the password. This PR fixes that and takes the liberty of adding an `OPENAI_` prefix to the env vars for clarity.