### PR TITLE
docs: add project for chatgpt shortcut

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,6 +247,7 @@ All of these awesome projects are built using the `chatgpt` package. 🤯
 - [Assistant CLI](https://github.com/diciaup/assistant-cli)
 - [Teams Bot](https://github.com/formulahendry/chatgpt-teams-bot)
 - [Askai](https://github.com/yudax42/askai)
+- [ChatGPT - Shortcuts for iOS](https://github.com/leecobaby/shortcuts/blob/master/ohter/ChatGPT_EN.md)
 
 If you create a cool integration, feel free to open a PR and add it to the list.
 

--- a/readme.md
+++ b/readme.md
@@ -247,7 +247,7 @@ All of these awesome projects are built using the `chatgpt` package. 🤯
 - [Assistant CLI](https://github.com/diciaup/assistant-cli)
 - [Teams Bot](https://github.com/formulahendry/chatgpt-teams-bot)
 - [Askai](https://github.com/yudax42/askai)
-- [ChatGPT - Shortcuts for iOS](https://github.com/leecobaby/shortcuts/blob/master/ohter/ChatGPT_EN.md)
+- [ChatGPT - Shortcuts for iOS](https://github.com/leecobaby/shortcuts/blob/master/other/ChatGPT_EN.md)
 
 If you create a cool integration, feel free to open a PR and add it to the list.
 

--- a/readme.md
+++ b/readme.md
@@ -247,7 +247,7 @@ All of these awesome projects are built using the `chatgpt` package. 🤯
 - [Assistant CLI](https://github.com/diciaup/assistant-cli)
 - [Teams Bot](https://github.com/formulahendry/chatgpt-teams-bot)
 - [Askai](https://github.com/yudax42/askai)
-- [ChatGPT - Shortcuts for iOS](https://github.com/leecobaby/shortcuts/blob/master/other/ChatGPT_EN.md)
+- [iOS Shortcut](https://github.com/leecobaby/shortcuts/blob/master/other/ChatGPT_EN.md)
 
 If you create a cool integration, feel free to open a PR and add it to the list.
 


### PR DESCRIPTION
It's a shortcut version implemented by [chantgpt-api](https://github.com/transitive-bullshit/chatgpt-api)