### PR TITLE
fix: properly handle messages with newlines

### DIFF
--- a/src/chatgpt-api-browser.ts
+++ b/src/chatgpt-api-browser.ts
@@ -199,8 +199,17 @@ export class ChatGPTAPIBrowser {
     const lastMessage = await this.getLastMessage()
 
     await inputBox.click()
-    await inputBox.type(message, { delay: 0 })
-    await inputBox.press('Enter')
+    const paragraphs = message.split('\n')
+    for (let i = 0; i < paragraphs.length; i++) {
+      await inputBox.type(paragraphs[i], { delay: 0 })
+      if (i < paragraphs.length - 1) {
+        await this._page.keyboard.down('Shift')
+        await inputBox.press('Enter')
+        await this._page.keyboard.up('Shift')
+      } else {
+        await inputBox.press('Enter')
+      }
+    }
 
     do {
       await delay(1000)


### PR DESCRIPTION
Pressing Enter would normally send the current message, so now the code splits it up by newlines and uses Shift+Enter unless it's the last split.