### PR TITLE
fix: can't find module "kind-of"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "del-cli": "^5.0.0",
     "dotenv-safe": "^8.2.0",
     "husky": "^8.0.2",
+    "kind-of": "^3.2.2",
     "lint-staged": "^13.0.3",
     "npm-run-all": "^4.1.5",
     "ora": "^6.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ specifiers:
   expiry-map: ^2.0.0
   html-to-md: ^0.8.3
   husky: ^8.0.2
+  kind-of: ^3.2.2
   lint-staged: ^13.0.3
   npm-run-all: ^4.1.5
   ora: ^6.1.2
@@ -51,6 +52,7 @@ devDependencies:
   del-cli: 5.0.0
   dotenv-safe: 8.2.0
   husky: 8.0.2
+  kind-of: 3.2.2
   lint-staged: 13.0.4
   npm-run-all: 4.1.5
   ora: 6.1.2


### PR DESCRIPTION
Added missing ```kind-of``` module. Got this error when I try to build my Raycast extension. 

Tried to add it to my package.json extension but seems the error it's located in your build. I've tried to use the ```patch-package``` to modify my ```chatgpt``` build by adding the ```kind-of``` module and it's working.

Now I thought it'd be nice if I can get mine working without patching every time I build just adding the ```kind-of``` module directly on yours.

![image](https://user-images.githubusercontent.com/7030944/207995228-34c2c01c-b8f2-401f-87be-f31a07d6bcf1.png)
