### PR TITLE
feat: Add browserPath option to ChatGPTAPIBrowser

### DIFF
--- a/src/chatgpt-api-browser.ts
+++ b/src/chatgpt-api-browser.ts
@@ -3,7 +3,11 @@ import type { Browser, HTTPRequest, HTTPResponse, Page } from 'puppeteer'
 import { v4 as uuidv4 } from 'uuid'
 
 import * as types from './types'
-import { getBrowser, getOpenAIAuth } from './openai-auth'
+import {
+  defaultChromeExecutablePath,
+  getBrowser,
+  getOpenAIAuth
+} from './openai-auth'
 import {
   browserPostEventStream,
   isRelevantRequest,
@@ -22,6 +26,7 @@ export class ChatGPTAPIBrowser {
   protected _email: string
   protected _password: string
 
+  protected _browserPath: string
   protected _browser: Browser
   protected _page: Page
 
@@ -46,6 +51,9 @@ export class ChatGPTAPIBrowser {
 
     /** @defaultValue `undefined` **/
     captchaToken?: string
+
+    /** @defaultValue `undefined` **/
+    browserPath?: string
   }) {
     const {
       email,
@@ -54,7 +62,8 @@ export class ChatGPTAPIBrowser {
       debug = false,
       isGoogleLogin = false,
       minimize = true,
-      captchaToken
+      captchaToken,
+      browserPath = defaultChromeExecutablePath()
     } = opts
 
     this._email = email
@@ -65,6 +74,7 @@ export class ChatGPTAPIBrowser {
     this._isGoogleLogin = !!isGoogleLogin
     this._minimize = !!minimize
     this._captchaToken = captchaToken
+    this._browserPath = browserPath
   }
 
   async init() {
@@ -75,7 +85,10 @@ export class ChatGPTAPIBrowser {
     }
 
     try {
-      this._browser = await getBrowser({ captchaToken: this._captchaToken })
+      this._browser = await getBrowser({
+        captchaToken: this._captchaToken,
+        executablePath: this._browserPath
+      })
       this._page =
         (await this._browser.pages())[0] || (await this._browser.newPage())
 

--- a/src/openai-auth.ts
+++ b/src/openai-auth.ts
@@ -186,7 +186,11 @@ export async function getBrowser(
     captchaToken?: string
   } = {}
 ) {
-  const { captchaToken = process.env.CAPTCHA_TOKEN, ...launchOptions } = opts
+  const {
+    captchaToken = process.env.CAPTCHA_TOKEN,
+    executablePath = defaultChromeExecutablePath(),
+    ...launchOptions
+  } = opts
 
   if (captchaToken && !hasRecaptchaPlugin) {
     hasRecaptchaPlugin = true
@@ -207,7 +211,7 @@ export async function getBrowser(
     headless: false,
     args: ['--no-sandbox', '--exclude-switches', 'enable-automation'],
     ignoreHTTPSErrors: true,
-    executablePath: defaultChromeExecutablePath(),
+    executablePath,
     ...launchOptions
   })
 }


### PR DESCRIPTION
This PR introduces a new `browserOption` option for the `ChatGPTAPIBrowser` constructor, which allows users to specify the path to their preferred Chrome/Chromium executable for use with Puppeteer. If the `browserOption` value is defined, it will be used in place of the default path returned by `defaultChromeExecutablePath()`.

By providing this option, users have greater control over which browser is used to run Puppeteer, which can be useful in cases where the default executable path may not be correct or available on their system.

Closes #140