### PR TITLE
Update openai-auth.ts

### DIFF
--- a/src/openai-auth.ts
+++ b/src/openai-auth.ts
@@ -228,6 +228,7 @@ export async function getBrowser(
 
   const puppeteerArgs = [
     '--no-sandbox',
+    '--disable-setuid-sandbox',
     '--disable-infobars',
     '--disable-dev-shm-usage',
     '--disable-blink-features=AutomationControlled',


### PR DESCRIPTION
add --disable-setuid-sandbox so puppeteer works with the heroku buildpack for puppeteer on heroku