### PR TITLE
Fix 403 handling during sendMessage & 

### DIFF
--- a/src/chatgpt-api-browser.ts
+++ b/src/chatgpt-api-browser.ts
@@ -157,7 +157,7 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
       this._page.on('response', this._onResponse.bind(this))
 
       // bypass cloudflare and login
-      await getOpenAIAuth({
+      var authInfo = await getOpenAIAuth({
         email: this._email,
         password: this._password,
         browser: this._browser,
@@ -165,6 +165,8 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
         isGoogleLogin: this._isGoogleLogin,
         isMicrosoftLogin: this._isMicrosoftLogin
       })
+      console.log('Cloudflare Cookie: ', authInfo.clearanceToken)
+      console.log('Useragent: ', authInfo.userAgent)
     } catch (err) {
       if (this._browser) {
         await this._browser.close()

--- a/src/chatgpt-api-browser.ts
+++ b/src/chatgpt-api-browser.ts
@@ -551,6 +551,7 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
         } else {
           await this.refreshSession()
           await delay(1000)
+          result = null
           continue
         }
       } else {

--- a/src/chatgpt-api-browser.ts
+++ b/src/chatgpt-api-browser.ts
@@ -32,6 +32,7 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
   protected _browser: Browser
   protected _page: Page
   protected _proxyServer: string
+  protected _isRefreshing: boolean
 
   /**
    * Creates a new client for automating the ChatGPT webapp.
@@ -95,6 +96,7 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
     this._nopechaKey = nopechaKey
     this._executablePath = executablePath
     this._proxyServer = proxyServer
+    this._isRefreshing = false
 
     if (!this._email) {
       const error = new types.ChatGPTError('ChatGPT invalid email')
@@ -280,7 +282,7 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
     }
 
     if (url.endsWith('/conversation')) {
-      if (status === 403) {
+      if (status === 403 && !this._isRefreshing) {
         await this.refreshSession()
       }
     } else if (url.endsWith('api/auth/session')) {
@@ -327,6 +329,7 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
    * Attempts to handle 403 errors by refreshing the page.
    */
   async refreshSession() {
+    this._isRefreshing = true
     console.log(`ChatGPT "${this._email}" session expired (403); refreshing...`)
     try {
       if (!this._minimize) {
@@ -372,6 +375,8 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
         `ChatGPT "${this._email}" error refreshing session`,
         err.toString()
       )
+    } finally {
+      this._isRefreshing = false
     }
   }
 

--- a/src/chatgpt-api-browser.ts
+++ b/src/chatgpt-api-browser.ts
@@ -357,6 +357,16 @@ export class ChatGPTAPIBrowser extends AChatGPTAPI {
         await minimizePage(this._page)
       }
       console.log(`ChatGPT "${this._email}" refreshed session successfully`)
+      const pageCookies = await this._page.cookies()
+      const cookies = pageCookies.reduce(
+        (map, cookie) => ({ ...map, [cookie.name]: cookie }),
+        {}
+      )
+      try {
+        console.log('Cloudflare Cookie: ', cookies['cf_clearance'].value)
+      } catch (error) {
+        console.log('Cloudflare Cookie: ', 'Not Found')
+      }
     } catch (err) {
       console.error(
         `ChatGPT "${this._email}" error refreshing session`,


### PR DESCRIPTION
This PR fixes the the failure to retry a request upon encountering a 403 status code (more details on that in the commit description). Also includes other small fixes like the double call to refreshSession() on 403 as well, and improving refreshSession() by making sure the Cloudflare Anti-bot page has completed before returning, which in fact fixes another related bug due to the early return which causes getIsAuthenticated() to return false (false positive) due to the cloudflare anti-bot page still being present and thus resetting the session (unnecessary). Finally, I have added logging for the `cf_clearance` on initSession() and refreshSession().