### PR TITLE
Wait more on password prompt

### DIFF
--- a/src/openai-auth.ts
+++ b/src/openai-auth.ts
@@ -212,7 +212,7 @@ export async function getOpenAIAuth({
         await submit.click()
         await page.waitForSelector('#password', { timeout: timeoutMs })
         await page.type('#password', password)
-        await delay(50)
+        await delay(200)
         submitP = () => page.click('button[type="submit"]')
       }
 


### PR DESCRIPTION
50ms of delay would likely to fail the login because button not loaded, so wait more.