### PR TITLE
Write the underlying exception details to streamed response

### DIFF
--- a/src/fetch-sse.ts
+++ b/src/fetch-sse.ts
@@ -12,7 +12,8 @@ export async function fetchSSE(
   const { onMessage, ...fetchOptions } = options
   const res = await fetch(url, fetchOptions)
   if (!res.ok) {
-    const msg = `ChatGPT error ${res.status || res.statusText}`
+    const reason = await res.text()
+    const msg = `ChatGPT error ${res.status || res.statusText}: ${reason}`
     const error = new types.ChatGPTError(msg, { cause: res })
     error.statusCode = res.status
     error.statusText = res.statusText


### PR DESCRIPTION
Currently, when stream is enabled the `fetchSSE` isn't returning the api response details.