### PR TITLE
added SendMessageOptions.queueWithCompletion

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type SendMessageOptions = {
   timeoutMs?: number
   onProgress?: (partialResponse: ChatMessage) => void
   abortSignal?: AbortSignal
+  queueWithCompletion?: string
 }
 
 export type MessageActionType = 'next' | 'variant'


### PR DESCRIPTION
As a way to directly upsert a message with a predefined reply. This allows for adding instructive turns without actually calling (billed) openAI endpoints.