### PR TITLE
Fixed typo in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,7 @@ const api = new ChatGPTAPI({
 })
 ```
 
-If you want to track the conversation, you'll need to pass the `parentMessageid` and `conversationid` like this:
+If you want to track the conversation, you'll need to pass the `parentMessageId` and `conversationId` like this:
 
 ```ts
 const api = new ChatGPTAPI({ apiKey: process.env.OPENAI_API_KEY })

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ We now provide three ways of accessing the unofficial ChatGPT API, all of which 
 | --------------------------- | ------ | -------- | ----------------- |
 | `ChatGPTAPI`                | ❌ No  | ✅ Yes   | ☑️ Mimics ChatGPT |
 | `ChatGPTUnofficialProxyAPI` | ✅ Yes | ☑️ Maybe | ✅ Real ChatGPT   |
-| `ChatGPAPIBrowser` (v3)     | ✅ Yes | ❌ No    | ✅ Real ChatGPT   |
+| `ChatGPTAPIBrowser` (v3)     | ✅ Yes | ❌ No    | ✅ Real ChatGPT   |
 
 **Note**: I recommend that you use either `ChatGPTAPI` or `ChatGPTUnofficialProxyAPI`.
 
@@ -184,7 +184,7 @@ const api = new ChatGPTAPI({
 })
 ```
 
-If you want to track the conversation, you'll need to pass the `parentMessageid` and `conversationid`:
+If you want to track the conversation, you'll need to pass the `parentMessageid` and `conversationid` like this:
 
 ```ts
 const api = new ChatGPTAPI({ apiKey: process.env.OPENAI_API_KEY })


### PR DESCRIPTION
Updated README.md documentation to correct spelling of `ChatGPTAPIBrowser ` which was previously `ChatGPAPIBrowser `, and also added a completing sentence to the code guide in README.md for the readers to understand the documentation well.