### PR TITLE
fix: use official system message by default

### DIFF
--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -78,7 +78,7 @@ export class ChatGPTAPI {
 
     if (this._systemMessage === undefined) {
       const currentDate = new Date().toISOString().split('T')[0]
-      this._systemMessage = `You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possiboe.\nCurrent date: ${currentDate}\n`
+      this._systemMessage = `You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible.\nKnowledge cutoff: 2021-09-01\nCurrent date: ${currentDate}`
     }
 
     this._maxModelTokens = maxModelTokens


### PR DESCRIPTION
Fixing a typo in the default system message which sometimes causes weird problems, including failure to retrieve certain information. Additionally, using the official knowledge cutoff seems to help.

See Chanzhaoyu/chatgpt-web#242 for an example.