### PR TITLE
Handle possible token expired errors

### DIFF
--- a/src/chatgpt-unofficial-proxy-api.ts
+++ b/src/chatgpt-unofficial-proxy-api.ts
@@ -219,8 +219,11 @@ export class ChatGPTUnofficialProxyAPI {
               }
             } catch (err) {
               // ignore for now; there seem to be some non-json messages
-              // console.warn('fetchSSE onMessage unexpected error', err)
+              reject(err)
             }
+          },
+          onError: (err) => {
+            reject(err)
           }
         },
         this._fetch


### PR DESCRIPTION
The unofficial API actually returns `200 OK` and

```
{"detail":{"message":"Your authentication token has expired. Please try signing in again.","type":"invalid_request_error","param":null,"code":"token_expired"}
```