### PR TITLE
fix: Add params for usage calculation and default normalize function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,10 @@ export type Role = 'user' | 'assistant' | 'system'
 
 export type FetchFn = typeof fetch
 
+export type NormalizeMessageFunction = (
+  current: openai.ChatCompletionRequestMessage
+) => string | Promise<string>
+
 export type ChatGPTAPIOptions = {
   apiKey: string
 
@@ -30,6 +34,8 @@ export type ChatGPTAPIOptions = {
   upsertMessage?: UpsertMessageFunction
 
   fetch?: FetchFn
+
+  normalizeMessage?: NormalizeMessageFunction
 }
 
 export type SendMessageOptions = {


### PR DESCRIPTION
I made the following modifications to the code because I suspected that OpenAI may have fixed a bug in their system, which was causing the token usage calculations to be incorrect. When I used the API a few days ago, I did not encounter these errors.

To address this issue, I tested various format functions and found a suitable one to use, which helped to improve the accuracy of the token usage calculations. This format function was tested by examining the usage in the backend.

```ts
  protected async _defaultNormalizeMessage(
    message: types.openai.ChatCompletionRequestMessage
  ) {
    return `role: ${message.role}\ncontent: ${message.content}`
  }
```

As the bug was caused by OpenAI's internal logic, I decided to add the normalizeMessage parameter to the code. This allows users to provide their own normalization function to calculate token usage, which may help to avoid similar issues in the future. By adding this parameter, it enables users of this library to have more control over the customization of the token usage calculation process.
```ts
  /**
   * Creates a new client wrapper ...
   *
   * @param normalizeMessage - Optional function to normalize a message and calculate the final token usage. If not provided, the default implementation will concatenate message.role and message.content, and return the length of the resulting string as the token usage. The default message format is role: ${message.role}\ncontent: ${message.content}.
   */
```