### PR TITLE
fix: last detail lost

### DIFF
--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -210,17 +210,15 @@ export class ChatGPTAPI {
 
                   if (response?.choices?.length) {
                     const delta = response.choices[0].delta
-                    if (delta?.content) {
-                      result.delta = delta.content
-                      result.text += delta.content
-                      result.detail = response
+                    result.delta = delta.content
+                    if (delta?.content) result.text += delta.content
+                    result.detail = response
 
-                      if (delta.role) {
-                        result.role = delta.role
-                      }
-
-                      onProgress?.(result)
+                    if (delta.role) {
+                      result.role = delta.role
                     }
+
+                    onProgress?.(result)
                   }
                 } catch (err) {
                   console.warn('OpenAI stream SEE event unexpected error', err)

--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -331,15 +331,17 @@ export class ChatGPTAPI {
     }
 
     const systemMessageOffset = messages.length
-    let nextMessages = messages.concat([
-      {
-        ...{
-          role: 'user',
-          content: text,
-          name: opts.name
-        }
-      }
-    ])
+    let nextMessages = text
+      ? messages.concat([
+          {
+            ...{
+              role: 'user',
+              content: text,
+              name: opts.name
+            }
+          }
+        ])
+      : messages
     let numTokens = 0
 
     do {


### PR DESCRIPTION
The last content returned by the API may be without content, like this:

```json
{"id": "chatcmpl-6sCTfbTbepsgh2wvCX9x1gELH7Kdc", "object": "chat.completion.chunk", "created":1678375695, "model": "gpt-3.5-turbo-0301", "choices":[{"delta":{}, "index":0, "finish_reason": "stop"}]}
```

If the content is judged to exist or not, the `detail` information is lost, including the `finish_reason`.