### PR TITLE
Feat: support conversationId field in ChatGPTAPI.sendMessage option

### DIFF
--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -120,6 +120,7 @@ export class ChatGPTAPI {
    *
    * @param message - The prompt message to send
    * @param opts.parentMessageId - Optional ID of the previous message in the conversation (defaults to `undefined`)
+   * @param opts.conversationId - Optional ID of the conversation (defaults to `undefined`)
    * @param opts.messageId - Optional ID of the message to send (defaults to a random UUID)
    * @param opts.systemMessage - Optional override for the chat "system message" which acts as instructions to the model (defaults to the ChatGPT system message)
    * @param opts.timeoutMs - Optional timeout in milliseconds (defaults to no timeout)
@@ -139,7 +140,8 @@ export class ChatGPTAPI {
       timeoutMs,
       onProgress,
       stream = onProgress ? true : false,
-      completionParams
+      completionParams,
+      conversationId = ''
     } = opts
 
     let { abortSignal } = opts
@@ -154,7 +156,8 @@ export class ChatGPTAPI {
       role: 'user',
       id: messageId,
       parentMessageId,
-      text
+      text,
+      conversationId
     }
     await this._upsertMessage(message)
 
@@ -167,7 +170,8 @@ export class ChatGPTAPI {
       role: 'assistant',
       id: uuidv4(),
       parentMessageId: messageId,
-      text: ''
+      text: '',
+      conversationId
     }
 
     const responseP = new Promise<types.ChatMessage>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type SendMessageOptions = {
   /** The name of a user in a multi-user chat. */
   name?: string
   parentMessageId?: string
+  conversationId?: string
   messageId?: string
   stream?: boolean
   systemMessage?: string


### PR DESCRIPTION
Expect to specify `conversationId` in option of `sendMessage` , ChatGPTAPI .

So we can support multi-conversation chat。After message save,  query whole conversation infomation according to fieldname: `conversationId` from custom database,  rather than last message's `parentMessageId`.

In fact, there are serveral conversation in the same database(maybe mysql, mongodb), every message in one conversation should has  same identity, so that they can quickly be found / deleted。
 
Usage like:
```
sendMessage(text, { parentMessageId: PID, conversationId: MyConversationId })
```
Then query them:
```
// Get all message in specified conversation
mongoCollection.find({ conversationId: MyConversationId })

// Delete all message in specified conversation
mongoCollection.delete({ conversationId: MyConversationId })
```