### PR TITLE
#477 Estimate tokens usage with streaming completions

### DIFF
--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -294,7 +294,8 @@ export class ChatGPTAPI {
         message.detail.usage = {
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
-          total_tokens: promptTokens + completionTokens
+          total_tokens: promptTokens + completionTokens,
+          estimated: true
         }
       }
       return this._upsertMessage(message).then(() => message)

--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -211,15 +211,16 @@ export class ChatGPTAPI {
                     result.id = response.id
                   }
 
-                  if (response?.choices?.length) {
+                  if (response.choices?.length) {
                     const delta = response.choices[0].delta
                     result.delta = delta.content
                     if (delta?.content) result.text += delta.content
-                    result.detail = response
 
                     if (delta.role) {
                       result.role = delta.role
                     }
+
+                    result.detail = response
 
                     onProgress?.(result)
                   }
@@ -286,7 +287,16 @@ export class ChatGPTAPI {
           }
         }
       }
-    ).then((message) => {
+    ).then(async (message) => {
+      if (message.detail && !message.detail.usage) {
+        const promptTokens = numTokens
+        const completionTokens = await this._getTokenCount(message.text)
+        message.detail.usage = {
+          prompt_tokens: promptTokens,
+          completion_tokens: completionTokens,
+          total_tokens: promptTokens + completionTokens
+        }
+      }
       return this._upsertMessage(message).then(() => message)
     })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,13 +59,25 @@ export type SendMessageBrowserOptions = {
   abortSignal?: AbortSignal
 }
 
+interface CreateChatCompletionStreamResponse
+  extends openai.CreateChatCompletionDeltaResponse {
+  usage: CreateCompletionStreamResponseUsage
+}
+
+interface CreateCompletionStreamResponseUsage
+  extends openai.CreateCompletionResponseUsage {
+  estimated: true
+}
+
 export interface ChatMessage {
   id: string
   text: string
   role: Role
   name?: string
   delta?: string
-  detail?: any
+  detail?:
+    | openai.CreateChatCompletionResponse
+    | CreateChatCompletionStreamResponse
 
   // relevant for both ChatGPTAPI and ChatGPTUnofficialProxyAPI
   parentMessageId?: string


### PR DESCRIPTION
Resolves https://github.com/transitive-bullshit/chatgpt-api/issues/477

When making requests with `stream` mode (passing `onProgress()`) [we don't have access](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_stream_completions.ipynb) to the tokens `usage` object
Alternatively, we can calculate tokens `tiktoken` - tokenized that, as they say, itself used in ChatGPT. Actually, cahtgpt-api is already doing it for calculating allowed length of message history sent to ChatGPT. 
So the only thing I've added:
  * calculated tokens of complete response in a streamed message
  * added it to a message object before return to user
  * added types for `ChatMessage.detail` to safely read those fields in TS