### PR TITLE
Mark user message as required

### DIFF
--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -400,7 +400,7 @@ export class ChatGPTAPI {
           }
         }, [] as string[])
         .join('\n\n')
-      const nextNumTokensEstimate = (await this._getTokenCount(prompt)) + 8 // TODO: find out where this 8 tokens diff comes from
+      const nextNumTokensEstimate = await this._getTokenCount(prompt)
       const validatingRequiredMessages =
         nextMessages.length <= requiredMessagesAmount
       const promptLimit = validatingRequiredMessages


### PR DESCRIPTION
I found a conflict with `maxResponseTokens` @transitive-bullshit 

### Problem 1

From one side, `buildMessages()` now has logic to limit prompt length, because we include "history messages" and wanna know when to stop adding them. From another hand, prompt length defines a length of response, because total sub should not exceed `maxModelTokens`. The we have the following:

1. I don't send `parentMessageId`s in my chatbot, so my users send short prompts, but get responses only of 1000 tokens length, because it's a default value
2. I set `maxResponseTokens: 4096` as max allowed value, expect maximum length responses
3. But [the current logic filters out](https://github.com/transitive-bullshit/chatgpt-api/blob/main/src/chatgpt-api.ts#L405) user prompt, so we send just systemMessage to ChatGPT that has no sense and is confusing to user
4. I can reduce `maxResponseTokens`, but don't know for how much because I want to use full capacity of 4096 tokens but don't know what user prompt length is

### Solution

If user passed a prompt and it exceeds the limits, we should throw exception to him, instead of skipping the userPrompt and sending systemMessage only. Then let's mark systemMessage and userPromp as "required" messages, which means that if they are passed the take prioritized tokens space. And if they exceed limits - we throw exception.

Now the flow looks like this:
1. Validate systemMessage and userPromp, based on `maxModelTokens - 1` value, ignoring `maxResponseTokens`. Where `1` - minimum space for response. If user enters `maxModelTokens - 1` tokens length prompt, he will get 1 token in 
response. If he enters prompt bigger than `maxModelTokens - 1`, there will be an exception
2. Validate historyPrompts, based on `maxModelTokens - maxResponseTokens` value
3. Send calculated size for response, based on `numTokens` and `maxResponseTokens`