### PR TITLE
feat: Add optional wait time before throwing error

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type SendMessageOptions = {
   timeoutMs?: number
   onProgress?: (partialResponse: ChatMessage) => void
   abortSignal?: AbortSignal
+  waitTimeMsBeforeThrow?: number
   completionParams?: Partial<
     Omit<openai.CreateChatCompletionRequest, 'messages' | 'n' | 'stream'>
   >
@@ -60,6 +61,7 @@ export type SendMessageBrowserOptions = {
   timeoutMs?: number
   onProgress?: (partialResponse: ChatMessage) => void
   abortSignal?: AbortSignal
+  waitTimeMsBeforeThrow?: number
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Description
Add an optional parameter waitTimeMsBeforeThrow that allows users to control the behavior when a JSON parsing error occurs during data reception. When using chatgpt-unofficial-proxy, data may sometimes result in an error in the middle of parsing, which is typically due to invalid JSON data. However, subsequent onmessage events may be able to parse the data correctly. In such cases, adding this parameter can wait for a specified period of time before attempting to parse the subsequent data when an error occurs. If the subsequent data can be parsed correctly, then the previous error is ignored. The default value for this parameter is 0 to maintain backward compatibility.