### PR TITLE
feat: add context message count configuration option

### DIFF
--- a/src/chatgpt-api.ts
+++ b/src/chatgpt-api.ts
@@ -359,7 +359,7 @@ export class ChatGPTAPI {
   }
 
   protected async _buildMessages(text: string, opts: types.SendMessageOptions) {
-    const { systemMessage = this._systemMessage } = opts
+    let { systemMessage = this._systemMessage, messageCount } = opts
     let { parentMessageId } = opts
 
     const userLabel = USER_LABEL_DEFAULT
@@ -373,6 +373,7 @@ export class ChatGPTAPI {
         role: 'system',
         content: systemMessage
       })
+      if (typeof messageCount === 'number') messageCount++
     }
 
     const systemMessageOffset = messages.length
@@ -412,6 +413,10 @@ export class ChatGPTAPI {
       numTokens = nextNumTokensEstimate
 
       if (!isValidPrompt) {
+        break
+      }
+
+      if (typeof messageCount === 'number' && messages.length >= messageCount) {
         break
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export type SendMessageOptions = {
   completionParams?: Partial<
     Omit<openai.CreateChatCompletionRequest, 'messages' | 'n' | 'stream'>
   >
+  messageCount?: number
 }
 
 export type MessageActionType = 'next' | 'variant'


### PR DESCRIPTION
```typescript
api.sendMessage('Can you expand on that?', {
  parentMessageId: parentMessage.id,
  messageCount: 1 // If set to 1, only the current message will be sent (including systemMessage, if it exists)
})
```