### PR TITLE
Unofficial Proxy update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -376,7 +376,7 @@ Known reverse proxies run by community members include:
 
 | Reverse Proxy URL                                 | Author                                       | Rate Limits                  | Last Checked |
 | ------------------------------------------------- | -------------------------------------------- | ---------------------------- | ------------ |
-| `https://bypass.churchless.tech/api/conversation` | [@acheong08](https://github.com/acheong08)   | 5 req / 10 seconds by IP     | 3/24/2023    |
+| `https://ai.fakeopen.com/api/conversation` | [@pengzhile](https://github.com/pengzhile)   | 5 req / 10 seconds by IP     | 4/18/2023    |
 | `https://api.pawan.krd/backend-api/conversation`  | [@PawanOsman](https://github.com/PawanOsman) | 50 req / 15 seconds (~3 r/s) | 3/23/2023    |
 
 Note: info on how the reverse proxies work is not being published at this time in order to prevent OpenAI from disabling access.


### PR DESCRIPTION
Cloudflare added new fingerprints and made my proxy impractical at scale.

Users can run https://github.com/linweiyuan/go-chatgpt-api locally instead or use public proxy by @pengzhile