### PR TITLE
Support 'continue' action

### DIFF
--- a/src/chatgpt-unofficial-proxy-api.ts
+++ b/src/chatgpt-unofficial-proxy-api.ts
@@ -141,16 +141,20 @@ export class ChatGPTUnofficialProxyAPI {
 
     const body: types.ConversationJSONBody = {
       action,
-      messages: [
-        {
-          id: messageId,
-          role: 'user',
-          content: {
-            content_type: 'text',
-            parts: [text]
-          }
+      ...(
+        action === 'continue' ? {} : {
+          messages: [
+            {
+              id: messageId,
+              role: 'user',
+              content: {
+                content_type: 'text',
+                parts: [text]
+              }
+            }
+          ],
         }
-      ],
+      ),
       model: this._model,
       parent_message_id: parentMessageId
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export type SendMessageOptions = {
   >
 }
 
-export type MessageActionType = 'next' | 'variant'
+export type MessageActionType = 'next' | 'continue' | 'variant'
 
 export type SendMessageBrowserOptions = {
   conversationId?: string
@@ -118,8 +118,10 @@ export type ConversationJSONBody = {
 
   /**
    * Prompts to provide
+   *
+   * Should be null when the action is 'continue'
    */
-  messages: Prompt[]
+  messages?: Prompt[]
 
   /**
    * The model to use


### PR DESCRIPTION
When ChatGPT's answer is too long, generation stops, but the web app has a `Continue` button to resume. This is also present in the API.

The changes in this PR suffice to enable the `'continue'` action for my purpose (the `ChatGPTUnofficialProxyAPI`). I currently have no credits for the official API, so I haven't been able to make the changes required to that part of the code (hence the draft PR).